### PR TITLE
Allow the injection of an http client

### DIFF
--- a/http.go
+++ b/http.go
@@ -36,7 +36,7 @@ func (c *Client) GetHTTPResponseFromLeader(f func(Pid) url.URL) (*http.Response,
 
 // GetHTTPResponse will return a http.Response from a URL
 func (c *Client) GetHTTPResponse(u *url.URL) (*http.Response, error) {
-	resp, err := http.Get(u.String())
+	resp, err := c.Http.Get(u.String())
 
 	if err != nil {
 		return nil, err

--- a/megos.go
+++ b/megos.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"net/http"
 )
 
 // TODO Support new mesos version
@@ -20,6 +21,7 @@ type Client struct {
 	// Leader is the PID reference to the Leader of the Cluster (of Master URLs)
 	Leader *Pid
 	State  *State
+	Http *http.Client
 }
 
 // Pid is the process if per machine.
@@ -36,9 +38,13 @@ type Pid struct {
 // NewClient returns a new Megos / Mesos information client.
 // addresses has to be the the URL`s of the single nodes of the
 // Mesos cluster. It is recommended to apply all nodes in case of failures.
-func NewClient(addresses []*url.URL) *Client {
+func NewClient(addresses []*url.URL, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	client := &Client{
 		Master: addresses,
+		Http: httpClient,
 	}
 
 	return client

--- a/megos_test.go
+++ b/megos_test.go
@@ -58,7 +58,7 @@ func setup() {
 	m3, _ := url.Parse(server3.URL)
 	master = []*url.URL{m1, m2, m3}
 
-	client = NewClient(master)
+	client = NewClient(master, nil)
 }
 
 // teardown closes the test HTTP server.


### PR DESCRIPTION
This is an API breaking change that allows the injection of an HTTP client. This allows API consumers to handle special cases like TLS configurations. It's also just good practice.

Up to you if you want to change the existing APIs for it. We needed it, so I thought I'd make the PR.