### PR TITLE
Change http.Client to HTTPClient interface

### DIFF
--- a/http.go
+++ b/http.go
@@ -36,7 +36,7 @@ func (c *Client) GetHTTPResponseFromLeader(f func(Pid) url.URL) (*http.Response,
 
 // GetHTTPResponse will return a http.Response from a URL
 func (c *Client) GetHTTPResponse(u *url.URL) (*http.Response, error) {
-	resp, err := c.Http.Get(u.String())
+	resp, err := c.HTTP.Get(u.String())
 
 	if err != nil {
 		return nil, err

--- a/megos.go
+++ b/megos.go
@@ -12,6 +12,11 @@ import (
 // TODO Support new mesos version
 // @link http://mesos.apache.org/documentation/latest/upgrades/
 
+// HTTPClient allows the client to be changed to any valid client.
+type HTTPClient interface {
+	Get(url string) (res *http.Response, err error)
+}
+
 // Client manages the communication with the Mesos cluster.
 type Client struct {
 	sync.Mutex
@@ -23,7 +28,7 @@ type Client struct {
 	State           *State
 	System          *System
 	MetricsSnapshot *MetricsSnapshot
-	Http            *http.Client
+	HTTP            HTTPClient
 }
 
 // Pid is the process if per machine.
@@ -40,13 +45,13 @@ type Pid struct {
 // NewClient returns a new Megos / Mesos information client.
 // addresses has to be the the URL`s of the single nodes of the
 // Mesos cluster. It is recommended to apply all nodes in case of failures.
-func NewClient(addresses []*url.URL, httpClient *http.Client) *Client {
+func NewClient(addresses []*url.URL, httpClient HTTPClient) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	client := &Client{
 		Master: addresses,
-		Http:   httpClient,
+		HTTP:   httpClient,
 	}
 
 	return client


### PR DESCRIPTION
Allow use of any compatible HTTP client.

Examples:
* https://github.com/hashicorp/go-retryablehttp
* https://github.com/sethgrid/pester

Minor: change Http to HTTP for linter.